### PR TITLE
feat: 최초 실행 시 온보딩 화면 표시 기능 구현 _ SanWhatSanAPP 뷰만 수정했습니다.

### DIFF
--- a/SanWhatSan/App/SanWhatSanApp.swift
+++ b/SanWhatSan/App/SanWhatSanApp.swift
@@ -8,28 +8,25 @@
 import SwiftUI
 
 @main
+
 struct SanWhatSanApp: App {
-//    @StateObject private var LocationViewModel = MountainListViewModel()
-    //@StateObject private var cameraViewModel = CameraViewModel()
     @StateObject var coordinator = NavigationCoordinator()
-    @State private var showTutorial = true
+    @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
+
 
     var locationService = LocationService.shared
     
     var body: some Scene {
         WindowGroup {
             AppNavigationView()
-//                .onAppear{
-//                    LocationViewModel.requestLocationAccess() // TODO: 현재는 CameraView에서 하는데 나중에 앱 실행할 때로 바꾸기(LocationService.swift 따로 빼야 할듯)
-//                }
                 .preferredColorScheme(.light)
                 .environmentObject(coordinator)
-                .onAppear{
+                .onAppear {
                     locationService.requestLocationAccess()
                 }
-                .fullScreenCover(isPresented: $showTutorial) {
+                .fullScreenCover(isPresented: .constant(!hasSeenOnboarding)) {
                     CameraWrapperView {
-                        showTutorial = false
+                        hasSeenOnboarding = true
                     }
                 }
         }


### PR DESCRIPTION
1. 앱 최초 실행 시 hasSeenOnboarding == false
2. 그래서 CameraWrapperView(온보딩 화면)가 뜸
3. 시작하기 버튼 누르면 → hasSeenOnboarding = true
4. 이후 앱을 재실행하면 → hasSeenOnboarding == true 이므로 AppNavigationView가 바로 뜨게 하였습니다 !
